### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Ruby
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Build and test with Rake
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rake
+    - name: Lint with Rubocop
+      run: |
+        bundle exec rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       ast (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    power_assert (1.1.6)
     public_suffix (4.0.3)
     rainbow (3.0.0)
     rake (13.0.1)
@@ -82,6 +83,8 @@ GEM
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    test-unit (3.3.5)
+      power_assert
     turn (0.9.7)
       ansi
       minitest (~> 4)
@@ -97,6 +100,7 @@ DEPENDENCIES
   rake (~> 13.0.1)
   rubocop (>= 0.68.0, < 0.72.0)
   rubocop-jekyll (~> 0.10.0)
+  test-unit (~> 3.3.5)
   turn (~> 0.9.7)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     premonition (4.0.0)
-      jekyll (>= 2.0, < 5.0)
+      jekyll (>= 3.7, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,6 +10,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
+    ast (2.4.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.6)
     em-websocket (0.5.1)
@@ -21,6 +22,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
     jekyll (4.0.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -50,14 +52,31 @@ GEM
     mercenary (0.3.6)
     minitest (4.7.5)
     mocha (1.11.2)
+    parallel (1.19.1)
+    parser (2.7.0.4)
+      ast (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.3)
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rouge (3.16.0)
+    rubocop (0.71.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-jekyll (0.10.0)
+      rubocop (>= 0.68.0, < 0.72.0)
+      rubocop-performance (~> 1.2)
+    rubocop-performance (1.5.2)
+      rubocop (>= 0.71.0)
+    ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -76,6 +95,8 @@ DEPENDENCIES
   mocha (~> 1.11.2)
   premonition!
   rake (~> 13.0.1)
+  rubocop (>= 0.68.0, < 0.72.0)
+  rubocop-jekyll (~> 0.10.0)
   turn (~> 0.9.7)
 
 BUNDLED WITH

--- a/premonition.gemspec
+++ b/premonition.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0.1'
   s.add_development_dependency 'rubocop', '>= 0.68.0', '< 0.72.0'
   s.add_development_dependency 'rubocop-jekyll', '~> 0.10.0'
+  s.add_development_dependency 'test-unit', '~> 3.3.5'
   s.add_development_dependency 'turn', '~> 0.9.7'
-  
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,6 @@
 require 'test/unit'
 require 'mocha/test_unit'
 require 'premonition'
-require 'jekyll'
-require 'redcarpet'
 
 begin
   require 'turn'


### PR DESCRIPTION
This PR adds a CI build on GitHub Actions, to run tests with Rake, and check for Rubocop linting errors.

Currently, the lint checks don't pass, but I would like to make a separate PR for that. Same goes for some of the messages displayed in the tests.