### PR TITLE
Patching issue 29

### DIFF
--- a/lib/premonition/processor.rb
+++ b/lib/premonition/processor.rb
@@ -52,7 +52,9 @@ module Jekyll
       def load_references(content)
         refs = ["\n"]
         content.each_line do |l|
+          unless l.nil? || l == 0 || (l.is_a? String) 
           refs << l if l.to_s.strip!.match(/^\[.*\]:.*\".*\"$/i)
+          end
         end
         refs
       end

--- a/lib/premonition/processor.rb
+++ b/lib/premonition/processor.rb
@@ -52,7 +52,7 @@ module Jekyll
       def load_references(content)
         refs = ["\n"]
         content.each_line do |l|
-          refs << l if l.strip!.match(/^\[.*\]:.*\".*\"$/i)
+          refs << l if l.to_s.strip!.match(/^\[.*\]:.*\".*\"$/i)
         end
         refs
       end

--- a/lib/premonition/processor.rb
+++ b/lib/premonition/processor.rb
@@ -53,7 +53,7 @@ module Jekyll
         refs = ["\n"]
         content.each_line do |l|
           unless l.nil? || l == 0 || (l.is_a? String) 
-          refs << l if l.to_s.strip!.match(/^\[.*\]:.*\".*\"$/i)
+            refs << l if l.to_s.strip!.match(/^\[.*\]:.*\".*\"$/i)
           end
         end
         refs

--- a/lib/premonition/processor.rb
+++ b/lib/premonition/processor.rb
@@ -24,7 +24,7 @@ module Jekyll
           if is_code_block
             o << l
           elsif blockquote?(l) && empty_block?(b)
-            if (m = l.match(/^\s*\>\s+([a-z]+)\s+\"(.*)\"\s+(\[.*\])?\s*$/i))
+            if (m = l.to_s.match(/^\s*\>\s+([a-z]+)\s+\"(.*)\"\s+(\[.*\])?\s*$/i))
               y, t, attrs = m.captures
               b = { 'title' => t.strip, 'type' => y.strip.downcase, 'content' => [], 'attrs' => attrs }
             else

--- a/lib/premonition/processor.rb
+++ b/lib/premonition/processor.rb
@@ -31,7 +31,7 @@ module Jekyll
               o << l
             end
           elsif blockquote?(l) && !empty_block?(b)
-            b['content'] << l.match(/^\s*\>\s?(.*)$/i).captures[0]
+            b['content'] << l.to_s.match(/^\s*\>\s?(.*)$/i).captures[0]
           else
             if !blockquote?(l) && !empty_block?(b)
               o << render_block(b, references)


### PR DESCRIPTION
- [x] using `to_s`  method  to returns string representation of an object

- [x] using `unless l.nil? || l == 0 || (l.is_a? String)  ... end` filter string is not null, zero value or not string before `ref <<`

Submit as patch for #29 