### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the following line to your `Gemfile` inside your Jekyll project folder:
 
 ```
 group :jekyll_plugins do
-  gem "premonition", "4.0.0"
+  gem "premonition", "4.0.1"
 end
 ```
 
@@ -138,7 +138,7 @@ Error
 Citation (Note the use of attributes here)
 
 ```markdown
-> citations "Mark Twain" [ cite = "mt" ]
+> citation "Mark Twain" [ cite = "mt" ]
 > I will be a beautiful citation quote
 ```
 


### PR DESCRIPTION
Version 4.0.1 is required as the one mentioned ends with error: https://github.com/lazee/premonition/issues/29

"citations" is a typo, the correct name is "citation" [I'm ashamed that it took me 10 minutes to figure out that's what crashed my build :))]